### PR TITLE
Generate correct markup for selected options.

### DIFF
--- a/src/crate/form.cljs
+++ b/src/crate/form.cljs
@@ -66,10 +66,12 @@
   ([coll] (select-options coll nil))
   ([coll selected]
     (for [x coll]
-      (if (sequential? x)
-        (let [[text val] x]
-          [:option {:value val :selected (= val selected)} text])
-        [:option {:selected (= x selected)} x]))))
+      (let [[text val] (if (sequential? x) x [x x])
+            attr {:value val}
+            attr (if (= val selected)
+                   (assoc attr :selected "selected")
+                   attr)]
+        [:option attr text]))))
 
 (defelem drop-down
   ([name options] (drop-down name options nil))


### PR DESCRIPTION
Previously, each <option> had a "selected=..." attribute, with its value set to true or false depending on whether it was supposed to be selected.  Browsers interpret this to mean that we want them all to be selected.  The correct behavior is to leave out the "selected" attribute for all but the element that is to be selected.

This is also a problem in hiccup.  See the pull request for that here: https://github.com/weavejester/hiccup/pull/50 .
